### PR TITLE
Free card fix, hand trap support

### DIFF
--- a/src/utils/card-details.ts
+++ b/src/utils/card-details.ts
@@ -109,3 +109,16 @@ export interface CardDetails {
      */
     free?: FreeCardDetails;
 }
+
+export interface HandTrapDetails {
+    /**
+     * How many of this card can be activated per turn. Technical issue with Mulcharmy monsters, unresolved.
+     */
+    count?: number;
+
+    /**
+     * If the hand trap requires you to have no cards on field to activate. Therefore, likely only a valid hand trap when going second.
+     */
+    goingSecond: boolean;
+
+}

--- a/src/utils/details-provider.ts
+++ b/src/utils/details-provider.ts
@@ -1,4 +1,4 @@
-import { CardDetails, FreeCardDetails, CostType, ConditionType, RestrictionType } from './card-details';
+import { CardDetails, FreeCardDetails, CostType, ConditionType, RestrictionType, HandTrapDetails } from './card-details';
 import { CardInformation } from './card-information';
 
 const freeCardMap: Record<string, FreeCardDetails> = {
@@ -13,7 +13,7 @@ const freeCardMap: Record<string, FreeCardDetails> = {
     'Pot of Extravagance': {
         count: 2,
         oncePerTurn: false,
-        restriction: [RestrictionType.NoPreviousDraws, RestrictionType.NoMoreDraws]
+        restriction: [RestrictionType.NoMoreDraws]
     },
     'Pot of Prosperity': {
         count: 0,
@@ -59,6 +59,14 @@ const freeCardMap: Record<string, FreeCardDetails> = {
             type: CostType.Discard,
             value: ["Level 8"]
         }
+    }, 
+    'Sacred Sword of Seven Stars': {
+        count: 2,
+        oncePerTurn: true,
+        condition: {
+            type: ConditionType.BanishFromHand,
+            value: "Level 7"
+        }
     },
     'Spellbook of Knowledge': {
         count: 2,
@@ -68,6 +76,154 @@ const freeCardMap: Record<string, FreeCardDetails> = {
             value: ["Spellcaster", "Spellbook"]
         }
     }
+};
+
+const handTrapMap: Record<string, HandTrapDetails> = {
+    'Ash Blossom & Joyous Spring': {
+        count: 1,
+        goingSecond: false,
+
+    },
+    'Ghost Belle & Haunted Mansion': {
+        count: 1,
+        goingSecond: false,
+
+    },
+    'Ghost Ogre & Snow Rabbit': {
+        count: 1,
+        goingSecond: false,
+
+    },
+    'Ghost Mourner & Moonlit Chill': {
+        count: 1,
+        goingSecond: false,
+
+    },
+    'Ghost Reaper & Winter Cherries': {
+        count: 1,
+        goingSecond: false,
+
+    },
+    'Ghost Sister & Spooky Dogwood': {
+        count: 1,
+        goingSecond: false,
+
+    },
+    'Maxx "C"': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Retaliating "C"': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Contact "C"': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Flying "C"': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Dimension Shifter': {
+        count: 1, 
+        goingSecond: false,
+    },
+    'Effect Veiler': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Droll & Lock Bird': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Nibiru, the Primal Being': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Fantastical Dragon Phantazmay': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Gnomaterial': {
+        count: 1,
+        goingSecond: true,
+    },
+    'Mulcharmy Fuwaross': {
+        count: 2,
+        goingSecond: true,
+    },
+    'Mulcharmy Purulia': {
+        count: 2,
+        goingSecond: true,
+    },
+    'D.D. Crow': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Bystial Baldrake': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Bystial Druiswurm': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Bystial Magnamhut': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Bystial Saronir': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Skull Meister': {
+        count: 3,
+        goingSecond: false,
+    },
+    /**
+     * Technically, you can only use one of the PYS-Framegears per turn - same issue as with the Mulcharmy monsters.
+     */
+    'PSY-Framegear Alpha': {
+        count: 1,
+        goingSecond: true,
+    },
+    'PSY-Framegear Beta': {
+        count: 1,
+        goingSecond: true,
+    },
+    'PSY-Framegear Gamma': {
+        count: 1,
+        goingSecond: true,
+    },
+    'PSY-Framegear Delta': {
+        count: 1,
+        goingSecond: true,
+    },
+    'PSY-Framegear Epsilon': {
+        count: 1,
+        goingSecond: true,
+    },
+    'Infinite Impermanence': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Typhoon': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Red Reboot': {
+        count: 3,
+        goingSecond: false,
+    },
+    'Dominus Purge': {
+        count: 1,
+        goingSecond: false,
+    },
+    'Dominus Impulse': {
+        count: 1,
+        goingSecond: false,
+    }   
 };
 
 export async function getCardDetails(info: CardInformation): Promise<CardDetails> {


### PR DESCRIPTION
Fixed free card issue on Pot of Extravagance, added Sacred Sword of Seven Stars to free cards, adding foundation for automatic hand trap tags